### PR TITLE
Minor typos

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -134,7 +134,7 @@ I worked on a package in 2019, and then sent it in in 2020. I got the following 
 
 > Should the year in the LICENSE file be updated?
 
-I updated the license year to 2020 and resubmit the package in. I then nicely replied directly to my reviewer and thanked them for catching the year discrepency, and then asked them if they could help me push the package through without needing another review, since that was the only change that had to be made.
+I updated the license year to 2020 and resubmit the package in. I then nicely replied directly to my reviewer and thanked them for catching the year discrepancy, and then asked them if they could help me push the package through without needing another review, since that was the only change that had to be made.
 
 </details>
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -162,8 +162,8 @@ I had originally commented out some code in an example that would otherwise modi
 
 > Examples/code lines in examples should never be commented out.
 Ideally find toy examples that can be regularly executed and checked.
-Lengthy examples (> 5 sec), can be wrapped in \donttest{}. If you don't
-want your code to be executed but still visible to the user, use \dontrun{}.
+Lengthy examples (> 5 sec), can be wrapped in `\donttest{}`. If you don't
+want your code to be executed but still visible to the user, use `\dontrun{}`.
 
 I didn't want any of these options, so I removed the code from the examples section entirely and just mentioned it in the `@details` section instead.
 

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ following question back:
 
 I updated the license year to 2020 and resubmit the package in. I then
 nicely replied directly to my reviewer and thanked them for catching the
-year discrepency, and then asked them if they could help me push the
+year discrepancy, and then asked them if they could help me push the
 package through without needing another review, since that was the only
 change that had to be made.
 
@@ -226,8 +226,9 @@ message on submission:
 
 > Examples/code lines in examples should never be commented out. Ideally
 > find toy examples that can be regularly executed and checked. Lengthy
-> examples (\> 5 sec), can be wrapped in . If you don’t want your code
-> to be executed but still visible to the user, use .
+> examples (\> 5 sec), can be wrapped in `\donttest{}`. If you don’t
+> want your code to be executed but still visible to the user, use
+> `\dontrun{}`.
 
 I didn’t want any of these options, so I removed the code from the
 examples section entirely and just mentioned it in the `@details`


### PR DESCRIPTION
Thanks for this helpful list.

I spotted these minor typos while reading.

For Problem 10 I don't think the `\donttest` advice will work as of R version 4.0.0 because `R CMD check --as-cran` now runs `\donttest` examples, or at least that what the Utilities section of the changelog says [here](https://cran.r-project.org/doc/manuals/r-release/NEWS.html). So maybe the resolution needs a sentence explaining this.