### PR TITLE
Check for starting description with package name or "functions for…"

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -74,6 +74,11 @@ There can be a number of problems here:
 
 There can be a number of problems here:
 
+> Do not start the description with "This package", package name,
+title or "Functions for".
+
+While it may be intuitive to start a description this way, they are actually not allowed. For example, instead of "this package renders slides to different formats..." or "functions for rendering slides to different formats...", just use "Render slides to different formats...".
+
 > The Description field is intended to be a (one paragraph) description of what the package does and why it may be useful. Please elaborate.
 
 In this case my description was 1 sentence, which I had to expand into a 3-4 sentence paragraph with a broader description of the types of problems the package intended to help with.

--- a/README.Rmd
+++ b/README.Rmd
@@ -74,8 +74,7 @@ There can be a number of problems here:
 
 There can be a number of problems here:
 
-> Do not start the description with "This package", package name,
-title or "Functions for".
+> Do not start the description with "This package", package name, title or "Functions for".
 
 While it may be intuitive to start a description this way, they are actually not allowed. For example, instead of "this package renders slides to different formats..." or "functions for rendering slides to different formats...", just use "Render slides to different formats...".
 

--- a/README.md
+++ b/README.md
@@ -105,6 +105,14 @@ Your package DESCRIPTION Description is flagged.
 
 There can be a number of problems here:
 
+> Do not start the description with “This package”, package name, title
+> or “Functions for”.
+
+While it may be intuitive to start a description this way, they are
+actually not allowed. For example, instead of “this package renders
+slides to different formats…” or “functions for rendering slides to
+different formats…”, just use “Render slides to different formats…”.
+
 > The Description field is intended to be a (one paragraph) description
 > of what the package does and why it may be useful. Please elaborate.
 


### PR DESCRIPTION
I recently got this request, which I've seen before. CRAN does not allows descriptions to start with the package name or the phrase "functions for...".