### PR TITLE
data checks

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -201,3 +201,10 @@ The problem here is that `https://h3geo.org/docs/core-library/coordsystems#facei
 
 To determine if you have any redirecting URLs, you can use `urlchecker::url_check()` to find them (and find what they redirect to) and `urlchecker::url_update()` to automatically update them to their redirected URL.
 </details>
+
+<details>
+<summary>You get a note like "found 5 marked UTF-8 strings" in the check: "data for non-ASCII characters"</summary>
+
+This happens when you have non-ASCII characters in your data directory files, which is not checked by `devtools::check()`. You can use the undocumented function `tools:::.check_package_datasets(".")` for a quick check, or alternatively one can use `tools::showNonASCIIfile()`.
+
+</details>

--- a/README.md
+++ b/README.md
@@ -286,3 +286,15 @@ To determine if you have any redirecting URLs, you can use
 and `urlchecker::url_update()` to automatically update them to their
 redirected URL.
 </details>
+<details>
+<summary>
+You get a note like “found 5 marked UTF-8 strings” in the check: “data
+for non-ASCII characters”
+</summary>
+
+This happens when you have non-ASCII characters in your data directory
+files, which is not checked by `devtools::check()`. You can use the
+undocumented function `tools:::.check_package_datasets(".")` for a quick
+check, or alternatively one can use `tools::showNonASCIIfile()`.
+
+</details>


### PR DESCRIPTION
I found it especially difficult to find a simple way to check for this note. But I think these solutions give you a quick answer, without running e.g. a lengthy `rhub::check(platform = c("fedora-gcc-devel"))` which raised this note (while other checks did not in my case). I am not sure whether this causes actual rejection or removal of a package. Still thought it might be useful. Thanks for the list by the way!