### PR TITLE
Redundant title for r

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -82,13 +82,14 @@ There can be a number of problems here:
 
 - You must use title case with package Titles, generally capitalizing all words except articles like 'a' and 'the'. Base R's [`toTitleCase()`](https://stat.ethz.ch/R-manual/R-devel/library/tools/html/toTitleCase.html) might help with formatting. 
 
-- I've been flagged for a "redundant" title. I had: "A Toolkit for the Construction of Modeling Packages" which was flagged since "Toolkit for" seemed redundant. I changed it to "Construct Modeling Packages" and was accepted.
+- I've been flagged for a "redundant" title.
+  - I had: "A Toolkit for the Construction of Modeling Packages" which was flagged since "Toolkit for" seemed redundant. I changed it to "Construct Modeling Packages" and was accepted.
+  - I had "Command Argument Parsing for R" flagged because of the, admittedly, redundant "for R" 
 
 - You generally have to put all software and R package names in single quotes, this rule also applies to the Description section. For example, the riingo package is an interface to Tiingo's stock price api: https://github.com/business-science/riingo/blob/a19c662d9a2acb526a15d119e00afcd3fdc7c24c/DESCRIPTION#L3
 
 - An initial package submission was rejected with the request to reduce the length of the title to less than 65 characters.
 </details>
-
 
 <details>
 <summary>Your package DESCRIPTION Description is flagged.</summary>

--- a/README.Rmd
+++ b/README.Rmd
@@ -83,13 +83,14 @@ There can be a number of problems here:
 - You must use title case with package Titles, generally capitalizing all words except articles like 'a' and 'the'. Base R's [`toTitleCase()`](https://stat.ethz.ch/R-manual/R-devel/library/tools/html/toTitleCase.html) might help with formatting. 
 
 - I've been flagged for a "redundant" title.
-  - I had: "A Toolkit for the Construction of Modeling Packages" which was flagged since "Toolkit for" seemed redundant. I changed it to "Construct Modeling Packages" and was accepted.
-  - I had "Command Argument Parsing for R" flagged because of the, admittedly, redundant "for R" 
+  - I had "A Toolkit for the Construction of Modeling Packages" which was flagged since "Toolkit for" seemed redundant. I changed it to "Construct Modeling Packages" and was accepted.
+  - I had "Command Argument Parsing for R" flagged because of the, admittedly, redundant "for R".
 
 - You generally have to put all software and R package names in single quotes, this rule also applies to the Description section. For example, the riingo package is an interface to Tiingo's stock price api: https://github.com/business-science/riingo/blob/a19c662d9a2acb526a15d119e00afcd3fdc7c24c/DESCRIPTION#L3
 
 - An initial package submission was rejected with the request to reduce the length of the title to less than 65 characters.
 </details>
+
 
 <details>
 <summary>Your package DESCRIPTION Description is flagged.</summary>

--- a/README.md
+++ b/README.md
@@ -123,10 +123,13 @@ There can be a number of problems here:
   [`toTitleCase()`](https://stat.ethz.ch/R-manual/R-devel/library/tools/html/toTitleCase.html)
   might help with formatting.
 
-- I’ve been flagged for a “redundant” title. I had: “A Toolkit for the
-  Construction of Modeling Packages” which was flagged since “Toolkit
-  for” seemed redundant. I changed it to “Construct Modeling Packages”
-  and was accepted.
+- I’ve been flagged for a “redundant” title.
+
+  - I had: “A Toolkit for the Construction of Modeling Packages” which
+    was flagged since “Toolkit for” seemed redundant. I changed it to
+    “Construct Modeling Packages” and was accepted.
+  - I had “Command Argument Parsing for R” flagged because of the,
+    admittedly, redundant “for R”
 
 - You generally have to put all software and R package names in single
   quotes, this rule also applies to the Description section. For

--- a/README.md
+++ b/README.md
@@ -125,11 +125,11 @@ There can be a number of problems here:
 
 - I’ve been flagged for a “redundant” title.
 
-  - I had: “A Toolkit for the Construction of Modeling Packages” which
+  - I had “A Toolkit for the Construction of Modeling Packages” which
     was flagged since “Toolkit for” seemed redundant. I changed it to
     “Construct Modeling Packages” and was accepted.
   - I had “Command Argument Parsing for R” flagged because of the,
-    admittedly, redundant “for R”
+    admittedly, redundant “for R”.
 
 - You generally have to put all software and R package names in single
   quotes, this rule also applies to the Description section. For


### PR DESCRIPTION
Flagged for having `"for R"` in the package title.  Thought it could be good to note.

Tried reformatting the redundancy notes so they didn't seem too, err, redundant?