### PR TITLE
Clarify the "do not start the description with" point

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -94,7 +94,7 @@ There can be a number of problems here:
 
 There can be a number of problems here:
 
-> Do not start the description with "This package", package name, title or "Functions for".
+> Do not start the description with "This package", "Tools to", package name, title, "Functions for" or similar.
 
 While it may be intuitive to start a description this way, they are actually not allowed.
 For example, instead of "this package renders slides to different formats..." or "functions for rendering slides to different formats...", just use "Render slides to different formats...".

--- a/README.md
+++ b/README.md
@@ -124,8 +124,8 @@ There can be a number of problems here:
 
 There can be a number of problems here:
 
-> Do not start the description with “This package”, package name, title
-> or “Functions for”.
+> Do not start the description with “This package”, “Tools to”, package
+> name, title, “Functions for” or similar.
 
 While it may be intuitive to start a description this way, they are
 actually not allowed. For example, instead of “this package renders


### PR DESCRIPTION
I took the examples in that section literally and started the description of my package with "Tools to", which I saw in the description of some packages. This is no longer allowed so I suggest to make that point more general.